### PR TITLE
Add memreport for lua 5.3.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lua-src"
-version = "544.0.1"
+version = "544.0.2"
 authors = ["Aleksandr Orlenko <zxteam@protonmail.com>"]
 edition = "2018"
 repository = "https://github.com/khvzak/lua-src-rs"

--- a/lua-5.3.6/lapi.c
+++ b/lua-5.3.6/lapi.c
@@ -1105,6 +1105,13 @@ LUA_API int lua_gc (lua_State *L, int what, int data) {
 }
 
 
+/*
+** memory report function
+*/
+LUA_API void lua_memoryreport (lua_State *L, lua_Memreport *report) {
+  luaC_report(L, report);
+}
+
 
 /*
 ** miscellaneous functions

--- a/lua-5.3.6/lgc.h
+++ b/lua-5.3.6/lgc.h
@@ -142,6 +142,7 @@ LUAI_FUNC void luaC_barrierback_ (lua_State *L, Table *o);
 LUAI_FUNC void luaC_upvalbarrier_ (lua_State *L, UpVal *uv);
 LUAI_FUNC void luaC_checkfinalizer (lua_State *L, GCObject *o, Table *mt);
 LUAI_FUNC void luaC_upvdeccount (lua_State *L, UpVal *uv);
+LUAI_FUNC void luaC_report (lua_State *L, lua_Memreport *report);
 
 
 #endif

--- a/lua-5.3.6/lua.h
+++ b/lua-5.3.6/lua.h
@@ -457,6 +457,25 @@ struct lua_Debug {
 
 /* }====================================================================== */
 
+typedef struct lua_Memreport {
+  int obj_count;
+  int thread_count;
+  int thread_size;
+  int table_count;
+  int table_size;
+  int short_string_count;
+  int short_string_size;
+  int long_string_count;
+  int long_string_size;
+  int lclosure_count;
+  int lclosure_size;
+  int cclosure_count;
+  int cclosure_size;
+  int userdata_count;
+  int userdata_size;
+  int proto_count;
+  int proto_size;
+} lua_Memreport;
 
 /******************************************************************************
 * Copyright (C) 1994-2020 Lua.org, PUC-Rio.


### PR DESCRIPTION
This change adds a custom memory reporting function to grab information about the current state of the lua runtime's memory consumption. The mechanism is intended to support use cases where a big-picture idea of where memory is going is needed.