### PR TITLE
Set 5.2 compat when using 5.3

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,10 @@ impl Build {
             _ => panic!("don't know how to build Lua for {}", target),
         };
 
+        if let Lua53 = version {
+            config.define("LUA_COMPAT_5_2", None);
+        }
+
         if let Lua54 = version {
             config.define("LUA_COMPAT_5_3", None);
             #[cfg(feature = "ucid")]


### PR DESCRIPTION
This change just sets a compatibility flag when using lua 5.3 for some deprecated 5.2 functionality.